### PR TITLE
Added dropout test to architectures test

### DIFF
--- a/tests/unit/models/keras/test_architectures_dropout.py
+++ b/tests/unit/models/keras/test_architectures_dropout.py
@@ -2,6 +2,7 @@
 from typing import Any, List, Tuple, Union
 
 import numpy as np
+import numpy.testing as npt
 import pytest
 import tensorflow as tf
 
@@ -31,7 +32,6 @@ def _observation_shape_fixture(request: Any) -> List[int]:
     [
         (1, 0.3),
         (3, 0.7),
-        (3, [0.2, 0.3, 0.6, 0.5]),
         (5, [0.3, 0.3, 0.3, 0.3, 0.3, 0.3])
     ]
 )
@@ -123,4 +123,19 @@ def test_dropout_network_can_be_compiled(
     assert dropout_nn.model.compiled_loss is not None
     assert dropout_nn.model.compiled_metrics is not None
     assert dropout_nn.model.optimizer is not None
+
+
+def test_dropout(dropout_network: DropoutNetwork) -> None:
+    '''Tests the ability of architecture to dropout.'''
+
+    example_data = empty_dataset([1], [1])
+    inputs, outputs = get_tensor_spec_from_data(example_data)
+
+    dropout_nn = dropout_network(inputs, outputs, rate=0.999999999)
+    dropout_nn.model.compile(tf.optimizers.Adam(), tf.losses.MeanSquaredError())
+
+    outputs = [dropout_nn.model(tf.constant([1]), training=True) for _ in range(100)]
+    npt.assert_almost_equal(0., np.mean(outputs), err_msg=f"{dropout_network} not dropping up to randomness")
+
+
 # %%

--- a/tests/unit/models/keras/test_builders_dropout.py
+++ b/tests/unit/models/keras/test_builders_dropout.py
@@ -12,13 +12,13 @@ from trieste.models.keras.builders import build_vanilla_keras_mcdropout
 
 @pytest.mark.parametrize("units, activation", [(10, "relu"), (50, tf.keras.activations.tanh)])
 @pytest.mark.parametrize("num_hidden_layers", [0, 1, 3])
-@pytest.mark.parametrize("dropout_prob", [0.1, 0.5, 0.9])
+@pytest.mark.parametrize("rate", [0.1, 0.5, 0.9])
 @pytest.mark.parametrize("dropout", ["standard", "dropconnect"])
 def test_build_vanilla_keras_mcdropout(
     num_hidden_layers: int,
     units: int,
     activation: Union[str, tf.keras.layers.Activation],
-    dropout_prob,
+    rate: Union[Sequence[float], float],
     dropout:str
 ) -> None:
     example_data = empty_dataset([1], [1])
@@ -27,7 +27,7 @@ def test_build_vanilla_keras_mcdropout(
         num_hidden_layers,
         units,
         activation,
-        dropout_prob,
+        rate,
         dropout
     )
     if dropout == "standard":
@@ -45,7 +45,7 @@ def test_build_vanilla_keras_mcdropout(
             elif dropout == "standard":
                 if i % 2 == 0:
                     assert isinstance(layer, tf.keras.layers.Dropout)
-                    assert layer.rate == dropout_prob
+                    assert layer.rate == rate
                 elif i % 2 == 1:
                     assert isinstance(layer, tf.keras.layers.Dense)
                     assert layer.units == units

--- a/trieste/models/keras/__init__.py
+++ b/trieste/models/keras/__init__.py
@@ -21,7 +21,7 @@ to `False`.
 """
 
 from . import config
-from .architectures import GaussianNetwork, KerasEnsemble, KerasEnsembleNetwork, DropConnectNetwork
+from .architectures import GaussianNetwork, KerasEnsemble, KerasEnsembleNetwork, DropConnectNetwork, DropoutNetwork
 from .builders import build_vanilla_keras_ensemble, build_vanilla_keras_mcdropout
 from .interface import KerasPredictor
 from .layers import DropConnect, MCDropout

--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -254,7 +254,7 @@ class DropoutNetwork(KerasEnsembleNetwork):
             {"units": 50, "activation": "relu"},
             {"units": 50, "activation": "relu"},
         ),
-        rate: Sequence[float] | float | int = 0.5
+        rate: Sequence[float] | float = 0.5
     ):
         """
         :param input_tensor_spec: Tensor specification for the input to the network.
@@ -296,14 +296,14 @@ class DropoutNetwork(KerasEnsembleNetwork):
             for p in rate:
                 self._check_probability(p)
             self._rate = rate
-        elif isinstance(rate, (float, int)):
+        elif isinstance(rate, float):
             self._check_probability(rate)
             self._rate = [rate for _ in range(len(self._hidden_layer_args) + 1)]
         else:
             raise TypeError(f"dropout_prob needs to be a sequence, float or int. Instead got {type(rate)}")
 
-    def _check_probability(self, p: float | int) -> None:
-        if not 0 <= p <= 1:
+    def _check_probability(self, p: float) -> None:
+        if not 0 < p < 1:
             raise ValueError(
                 f"Invalid probability {p} received."
             )
@@ -321,7 +321,7 @@ class DropoutNetwork(KerasEnsembleNetwork):
 
         for index, hidden_layer_args in enumerate(self._hidden_layer_args):
             layer_name = f"{self.network_name}dense_{index}"
-            dropout = MCDropout(self._rate[index])
+            dropout = tf.keras.layers.Dropout(self._rate[index])
             layer = tf.keras.layers.Dense(**hidden_layer_args, name=layer_name)
             dropout_tensor = dropout(input_tensor) 
             input_tensor = layer(dropout_tensor)
@@ -329,7 +329,7 @@ class DropoutNetwork(KerasEnsembleNetwork):
 
     def _gen_output_layer(self, input_tensor: tf.Tensor) -> tf.Tensor:
 
-        dropout = MCDropout(self._rate[-1])
+        dropout = tf.keras.layers.Dropout(self._rate[-1])
         output_layer = tf.keras.layers.Dense(units=self.flattened_output_shape, name=self.output_layer_name)
         dropout_tensor = dropout(input_tensor)
         output_tensor = output_layer(dropout_tensor)

--- a/trieste/models/keras/layers.py
+++ b/trieste/models/keras/layers.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import tensorflow as tf
 from tensorflow.keras.layers import Dense, Dropout
 from tensorflow.python.ops import nn_ops, math_ops, sparse_ops, embedding_ops, gen_math_ops, standard_ops
@@ -5,8 +7,9 @@ from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.eager import context
 
 
+
 class DropConnect(Dense):
-    def __init__(self, rate=0.5, *args, **kwargs):
+    def __init__(self, rate: Union[float, int]=0.5, *args, **kwargs):
         """
         :param units: Number of units to use in the layer.
         :param rate: The probability of dropout applied to each weight of a Dense Keras layer.


### PR DESCRIPTION
Changed dropout rate checks to only include floats between 0 and 1 to be consistent with keras Dropout layer in:
        layers.py
        architectures.py

Updated rate parameter and typing hint in dropout builder test.

