### PR TITLE
Quick fix to a shape issue in DropoutNetwork's new model architecture

### DIFF
--- a/trieste/models/keras/architectures.py
+++ b/trieste/models/keras/architectures.py
@@ -324,6 +324,9 @@ class DropoutNetwork(tf.keras.Model):
 
     def call(self, inputs: tf.Tensor) -> tf.Tensor:
 
+        if inputs.shape.rank == 1:
+            inputs = tf.expand_dims(inputs, axis=-1)
+
         hidden_output = self.hidden_layers(inputs)
         output = self.output_layer(hidden_output)
 

--- a/trieste/models/keras/models.py
+++ b/trieste/models/keras/models.py
@@ -441,7 +441,7 @@ class MCDropout(KerasPredictor, TrainableProbabilisticModel):
             ``query_points``.
         """
         stochastic_passes = tf.stack(
-            [self.model(query_points) for _ in range(self.num_passes)], axis=0
+            [self.model(query_points, training=True) for _ in range(self.num_passes)], axis=0
         )
         predicted_means = tf.math.reduce_mean(stochastic_passes, axis=0)
 


### PR DESCRIPTION
Issue that arose when we switched to subclassing tf.keras.Model. Quick fix here and pytest to come when I merge the branch with the Bayesian 
optimization integration tests. ﻿
